### PR TITLE
Allow upper- and lower-case in package name

### DIFF
--- a/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
+++ b/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
@@ -708,7 +708,7 @@ public class RpmMojo extends AbstractMojo
 
     private String makePackageName ()
     {
-        return this.packageName.toLowerCase ();
+        return this.packageName;
     }
 
     private RpmVersion makeVersion ()


### PR DESCRIPTION
Although it may be recommended to use only lower-case letters in RPM package names, this plugin should not enforce it. Leave it to the user to decide whether to follow it or not.

There are legitimate reasons (e.g., project-specific naming conventions) for using both upper- and lower-case letters in package names. Also, the various Linux distros have lots of packages that don't follow the recommendation. (e.g., release-notes-openSUSE, perl-XML-XPath, libX11-6, PackageKit, NetworkManager, Mesa, MozillaFirefox, etc. etc.).