### PR TITLE
Introduced skipDependencies property in YumMojo

### DIFF
--- a/src/main/java/de/dentrassi/rpm/builder/YumMojo.java
+++ b/src/main/java/de/dentrassi/rpm/builder/YumMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBH SYSTEMS GmbH and others.
+ * Copyright (c) 2016, 2017 IBH SYSTEMS GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
  * which accompanies this distribution, and is available at
@@ -8,6 +8,7 @@
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
  *     Red Hat Inc - upgrade to package drone 0.14.0
+ *     triggetry - introduced skipDependencies property
  *******************************************************************************/
 package de.dentrassi.rpm.builder;
 
@@ -122,7 +123,7 @@ public class YumMojo extends AbstractMojo
     private boolean skipSigning = false;
 
     /**
-     * Disable the use of rpms from maven dependency artifacts
+     * Disable the use of RPMs from maven dependency artifacts
      */
     @Parameter ( property = "rpm.skipDependencies", defaultValue = "false" )
     private boolean skipDependencies = false;
@@ -158,13 +159,16 @@ public class YumMojo extends AbstractMojo
 
             if ( !this.skipDependencies )
             {
-                this.logger.debug ( "Skipping rpm artifacts from maven dependencies" );
                 final Set<Artifact> deps = this.project.getArtifacts ();
                 if ( deps != null )
                 {
                     deps.forEach ( art -> addPackage ( creator, art.getFile () ) );
                     count++;
                 }
+            }
+            else
+            {
+                this.logger.debug ( "Skipped RPM artifacts from maven dependencies" );
             }
             if ( this.files != null )
             {

--- a/src/main/java/de/dentrassi/rpm/builder/YumMojo.java
+++ b/src/main/java/de/dentrassi/rpm/builder/YumMojo.java
@@ -8,7 +8,7 @@
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
  *     Red Hat Inc - upgrade to package drone 0.14.0
- *     triggetry - introduced skipDependencies property
+ *     Bernd Warmuth - introduced skipDependencies property
  *******************************************************************************/
 package de.dentrassi.rpm.builder;
 

--- a/src/main/java/de/dentrassi/rpm/builder/YumMojo.java
+++ b/src/main/java/de/dentrassi/rpm/builder/YumMojo.java
@@ -121,6 +121,12 @@ public class YumMojo extends AbstractMojo
     @Parameter ( property = "rpm.skipSigning", defaultValue = "false" )
     private boolean skipSigning = false;
 
+    /**
+     * Disable the use of rpms from maven dependency artifacts
+     */
+    @Parameter ( property = "rpm.skipDependencies", defaultValue = "false" )
+    private boolean skipDependencies = false;
+
     private Logger logger;
 
     @Override
@@ -150,11 +156,15 @@ public class YumMojo extends AbstractMojo
 
             int count = 0;
 
-            final Set<Artifact> deps = this.project.getArtifacts ();
-            if ( deps != null )
+            if ( !this.skipDependencies )
             {
-                deps.forEach ( art -> addPackage ( creator, art.getFile () ) );
-                count++;
+                this.logger.debug ( "Skipping rpm artifacts from maven dependencies" );
+                final Set<Artifact> deps = this.project.getArtifacts ();
+                if ( deps != null )
+                {
+                    deps.forEach ( art -> addPackage ( creator, art.getFile () ) );
+                    count++;
+                }
             }
             if ( this.files != null )
             {


### PR DESCRIPTION
The YumMojo is implemented in a way that it automatically takes any maven dependency artifacts to be included in the created yum repo. In this pull request i suggest to make this behavior optional.
I.e.: if the property `skipDependencies` is set to ` true` it will ignore all dependencies specified in the maven POM.