### PR TITLE
Made packageName & defaultScriptInterpreter configurable

### DIFF
--- a/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
+++ b/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
@@ -91,7 +91,7 @@ public class RpmMojo extends AbstractMojo
     /**
      * The RPM package name
      */
-    @Parameter ( defaultValue = "${project.artifactId}" )
+    @Parameter ( defaultValue = "${project.artifactId}", property = "rpm.packageName" )
     private String packageName;
 
     /**
@@ -329,7 +329,7 @@ public class RpmMojo extends AbstractMojo
      * one set explicitly, nor one could be detected
      */
     @Parameter ( property = "rpm.defaultScriptInterpreter", defaultValue = "/bin/sh" )
-    private final String defaultScriptInterpreter = "/bin/sh";
+    private String defaultScriptInterpreter;
 
     /**
      * RPM package requirements

--- a/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
+++ b/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
@@ -9,6 +9,7 @@
  *     IBH SYSTEMS GmbH - initial API and implementation
  *     Red Hat Inc - upgrade to package drone 0.14.0
  *     Bernd Warmuth - bugfix target folder creation
+ *     Oliver Richter - Made packageName & defaultScriptInterpreter configurable
  *******************************************************************************/
 package de.dentrassi.rpm.builder;
 


### PR DESCRIPTION
The defaultScriptInterpreter field was declared final and thus not configurable. (Also on the [script page](https://ctron.github.io/rpm-builder/scripts.html) ist is called "defaultInterpreter".)

Additionally I needed the possibility to specify an rpm package name different from the artifactId, which might be handy for others as well.