### PR TITLE
Support recommended and suggested dependencies

### DIFF
--- a/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
+++ b/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
@@ -388,6 +388,24 @@ public class RpmMojo extends AbstractMojo
     private final List<Dependency> requires = new LinkedList<> ();
 
     /**
+     * RPM package recommends
+     * <p>
+     * Also see <a href="deps.html">dependencies</a>
+     * </p>
+     */
+    @Parameter
+    private final List<Dependency> recommends = new LinkedList<> ();
+
+    /**
+     * RPM package suggests
+     * <p>
+     * Also see <a href="deps.html">dependencies</a>
+     * </p>
+     */
+    @Parameter
+    private final List<Dependency> suggests = new LinkedList<> ();
+
+    /**
      * RPM provides information
      * <p>
      * Also see <a href="deps.html">dependencies</a>
@@ -636,6 +654,8 @@ public class RpmMojo extends AbstractMojo
     private void fillDependencies ( final RpmBuilder builder )
     {
         addAllDependencies ( "require", this.requires, builder::addRequirement, RpmMojo::validateName, null );
+        addAllDependencies ( "recommend", this.recommends, builder::addRecommendation, RpmMojo::validateName, null );
+        addAllDependencies ( "suggest", this.suggests, builder::addSuggestion, RpmMojo::validateName, null );
         addAllDependencies ( "prerequire", this.prerequisites, builder::addRequirement, RpmMojo::validateName, flags -> flags.add ( RpmDependencyFlags.PREREQ ) );
         addAllDependencies ( "provide", this.provides, builder::addProvides, ( (Consumer<SimpleDependency>)RpmMojo::validateName ).andThen ( this::validateNoVersion ), null );
         addAllDependencies ( "conflict", this.conflicts, builder::addConflicts, RpmMojo::validateName, null );

--- a/src/site/markdown/deps.md
+++ b/src/site/markdown/deps.md
@@ -13,8 +13,10 @@ Also see:
 The RPM builder current does support the following dependency types of RPM:
 
 | Name | Tag | Spec Name | Type | Description |
-| ----- | ----- | ---------------- | ------------- |
+| ----- | ----- | ---------------- | ------------- | ------------- |
 | Requirement | `<requires>` | `requires` | Complex | Require another package or capability |
+| Recommendation | `<recommends>` | `recommends` | Complex | Recommend another package or capability |
+| Suggestion | `<suggests>` | `suggests` | Complex | Suggest another package or capability |
 | Prerequisite | `<prerequisites>` | `prereq` | Simple | Require another package or capability |
 | Provide capability | `<provides>` | `provides` | Simple | Provide a capability (aka virtual package) |
 | Conflict | `<conflicts>` | `conflicts` | Simple | Conflict with another package |
@@ -38,6 +40,14 @@ Scripts are configured using the normal plugin configuration:
             <require>…</require>
             <require>…</require>
         </requires>
+        <recommends>
+            <recommend>…</recommend>
+            <recommend>…</recommend>
+        </recommends>
+        <suggests>
+            <suggest>…</suggest>
+            <suggest>…</suggest>
+        </suggests>
       …
     </configuration>
 


### PR DESCRIPTION
This is an attempt to implement #27. It depends on https://github.com/eclipse/packagedrone/pull/127.

I have managed to build a package with recommended and suggested dependencies and tested it on available VMs. It seems to work from what I can tell. A more in-depth description can be found in https://github.com/eclipse/packagedrone/pull/127.

This obviously won't compile unless https://github.com/eclipse/packagedrone/pull/127 or corresponding code is released.