### PR TITLE
Make it possible to define relocations

### DIFF
--- a/src/it/test11-prefixes/pom.xml
+++ b/src/it/test11-prefixes/pom.xml
@@ -50,10 +50,10 @@
 							<group>Application/Misc</group>
 
 							<outputFileName>test11.rpm</outputFileName>
-                            <prefixes>
-                                <prefix>/opt</prefix>
-                                <prefix>/var/log</prefix>
-                            </prefixes>
+							<prefixes>
+								<prefix>/opt</prefix>
+								<prefix>/var/log</prefix>
+							</prefixes>
 
 							<signature>
 								<keyId>${keyId}</keyId>

--- a/src/it/test11-prefixes/pom.xml
+++ b/src/it/test11-prefixes/pom.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>de.dentrassi.maven.rpm.test</groupId>
+	<artifactId>test11-newflags</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>Test Package #11</name>
+	<description>
+	Test relocatable packages (prefixes)
+	</description>
+
+	<url>http://dentrassi.de</url>
+
+	<organization>
+		<name>Jens Reimann</name>
+		<url>http://dentrassi.de</url>
+	</organization>
+
+	<licenses>
+		<license>
+			<name>Eclipse Public License - v 1.0</name>
+			<distribution>repo</distribution>
+			<url>https://www.eclipse.org/legal/epl-v10.html</url>
+		</license>
+	</licenses>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<skipSigning>true</skipSigning>
+	</properties>
+
+	<build>
+
+		<plugins>
+			<plugin>
+				<groupId>de.dentrassi.maven</groupId>
+				<artifactId>rpm</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>rpm</goal>
+						</goals>
+						<configuration>
+							<group>Application/Misc</group>
+
+							<outputFileName>test11.rpm</outputFileName>
+                            <prefixes>
+                                <prefix>/opt</prefix>
+                                <prefix>/var/log</prefix>
+                            </prefixes>
+
+							<signature>
+								<keyId>${keyId}</keyId>
+								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
+								<passphrase>${passphrase}</passphrase>
+								<hashAlgorithm>SHA1</hashAlgorithm>
+								<skip>${skipSigning}</skip>
+							</signature>
+
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+			<id>sign</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<properties>
+				<skipSigning>false</skipSigning>
+			</properties>
+		</profile>
+	</profiles>
+
+</project>

--- a/src/it/test11-prefixes/pom.xml
+++ b/src/it/test11-prefixes/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>de.dentrassi.maven.rpm.test</groupId>
-	<artifactId>test11-newflags</artifactId>
+	<artifactId>test11-prefixes</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 
@@ -63,6 +63,22 @@
 								<skip>${skipSigning}</skip>
 							</signature>
 
+							<entries>
+								<entry>
+									<name>/opt/foo</name>
+									<directory>true</directory>
+									<user>root</user>
+									<group>root</group>
+									<mode>0755</mode>
+								</entry>
+								<entry>
+									<name>/opt/foo/foo.txt</name>
+									<file>src/main/resources/foo.txt</file>
+									<user>root</user>
+									<group>root</group>
+									<mode>0600</mode>
+								</entry>
+							</entries>
 						</configuration>
 					</execution>
 				</executions>

--- a/src/it/test11-prefixes/pom.xml
+++ b/src/it/test11-prefixes/pom.xml
@@ -72,11 +72,11 @@
 									<mode>0755</mode>
 								</entry>
 								<entry>
-									<name>/opt/foo/foo.txt</name>
-									<file>src/main/resources/foo.txt</file>
+									<name>/var/log/foo</name>
+									<directory>true</directory>
 									<user>root</user>
 									<group>root</group>
-									<mode>0600</mode>
+									<mode>0755</mode>
 								</entry>
 							</entries>
 						</configuration>

--- a/src/it/test11-prefixes/verify.groovy
+++ b/src/it/test11-prefixes/verify.groovy
@@ -1,11 +1,10 @@
-
 def prefixes ( ) {
-	Process proc = ('rpm --qf "[%{Prefixes}\n]" -qp ' + basedir + "/target/test11.rpm").execute();
-	return proc.in.getText().trim();
+	Process proc = ('rpm --qf [%{Prefixes}:] -qp ' + basedir + "/target/test11.rpm").execute()
+	return proc.in.getText().trim()
 }
 
-def result = prefixes();
-println "Prefixes: " + result;
+def result = prefixes()
+println "Prefixes: " + result
 
 
-return result ==  "/opt\n/var/log\n";
+return result ==  "/opt:/var/log:"

--- a/src/it/test11-prefixes/verify.groovy
+++ b/src/it/test11-prefixes/verify.groovy
@@ -1,0 +1,11 @@
+
+def prefixes ( ) {
+	Process proc = ('rpm --qf "[%{Prefixes}\n]" -qp ' + basedir + "/target/test11.rpm").execute();
+	return proc.in.getText().trim();
+}
+
+def result = prefixes();
+println "Prefixes: " + result;
+
+
+return result ==  "/opt\n/var/log\n";

--- a/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
+++ b/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
@@ -947,9 +947,10 @@ public class RpmMojo extends AbstractMojo
             return;
         }
 
-        this.logger.debug ( "Building relocatable package: " + this.prefixes );
+        this.logger.debug ( "Building relocatable package: {}", this.prefixes );
 
         builder.setHeaderCustomizer(rpmTagHeader -> {
+            // TODO: migrate to flags once https://github.com/eclipse/packagedrone/issues/130 is fixed
             int RPMTAG_PREFIXES = 1098; // see http://ftp.rpm.org/max-rpm/s1-rpm-file-format-rpm-file-format.html
             rpmTagHeader.putStringArray(RPMTAG_PREFIXES, this.prefixes.toArray(new String[0]));
         });

--- a/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
+++ b/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
@@ -334,6 +334,21 @@ public class RpmMojo extends AbstractMojo
     private String packager;
 
     /**
+     * Build relocatable packages.
+     *
+     * <pre>
+     *       &lt;prefixes&gt;
+     *           &lt;prefix&gt;/opt&lt;/prefix&gt;
+     *           &lt;prefix>/var/log&lt;/prefix&gt;
+     *       &lt;/prefixes&gt;
+     * </pre>
+     *
+     * See also <a href="http://ftp.rpm.org/max-rpm/s1-rpm-reloc-prefix-tag.html">The prefix tag</a>
+     */
+    @Parameter ( property = "rpm.prefixes" )
+    private List<String> prefixes;
+
+    /**
      * The actual payload/file entries
      * <p>
      * Also see <a href="entry.html">entries</a>
@@ -675,6 +690,7 @@ public class RpmMojo extends AbstractMojo
             fillScripts ( builder );
             fillDependencies ( builder );
             fillPayload ( builder );
+            fillPrefixes ( builder );
 
             // add signer
 
@@ -922,6 +938,21 @@ public class RpmMojo extends AbstractMojo
 
             fillFromEntry ( ctx, entry );
         }
+    }
+
+    private void fillPrefixes(  final RpmBuilder builder  )
+    {
+        if ( this.prefixes == null || this.prefixes.isEmpty() )
+        {
+            return;
+        }
+
+        this.logger.debug ( "Building relocatable package: " + this.prefixes );
+
+        builder.setHeaderCustomizer(rpmTagHeader -> {
+            int RPMTAG_PREFIXES = 1098; // see http://ftp.rpm.org/max-rpm/s1-rpm-file-format-rpm-file-format.html
+            rpmTagHeader.putStringArray(RPMTAG_PREFIXES, this.prefixes.toArray(new String[0]));
+        });
     }
 
     private void fillFromEntry ( final BuilderContext ctx, final PackageEntry entry ) throws IOException

--- a/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
+++ b/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
@@ -10,6 +10,7 @@
  *     Red Hat Inc - upgrade to package drone 0.14.0, enhance features
  *     Bernd Warmuth - bugfix target folder creation
  *     Oliver Richter - Made packageName & defaultScriptInterpreter configurable
+ *     Lucian Burja - Added setting for creating relocatable RPM packages
  *******************************************************************************/
 package de.dentrassi.rpm.builder;
 


### PR DESCRIPTION
This commit makes it possible to make relocatable rpm packages, by defining a new tag <prefixes> which maps to the Prefix tag of the rpm spec:

```
<configuration>
      ...
      <prefixes>
             <prefix>/opt</prefix>
             <prefix>/var/log</prefix>
      </prefixes>
       ...
</configuration>
```

The resulting rpm can later on be installed to a different path than the default: 

`rpm -Uvh --relocate /opt=/usr/local my-package.rpm`

I haven't been able to run the integration tests since I don't have a Linux machine for development, but the code as such I've tested by installing the relocatable rpm on Linux at the desired location.

