### PR TITLE
added support for basic file filtering when adding an explicit file

### DIFF
--- a/src/main/java/de/dentrassi/rpm/builder/BeanUtils.java
+++ b/src/main/java/de/dentrassi/rpm/builder/BeanUtils.java
@@ -1,0 +1,151 @@
+/*******************************************************************************
+ * Copyright (c) 2019 University of Waikato, Hamilton, NZ
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * Contributors:
+ *     University of Waikato, Hamilton, NZ - initial API and implementation
+ *******************************************************************************/
+package de.dentrassi.rpm.builder;
+
+import org.apache.maven.plugin.logging.Log;
+
+import java.beans.BeanInfo;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Array;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Bean related operations.
+ *
+ * @author FracPete (fracpete at waikato dot ac dot nz)
+ */
+public class BeanUtils
+{
+
+    /**
+     * Extracts the properties from an object.
+     *
+     * @param log for logging
+     * @param obj the object to inspect
+     * @return the properties
+     */
+    public static PropertyDescriptor[] extractProperties(Log log, Object obj)
+    {
+        BeanInfo bi;
+
+        if (obj == null)
+        {
+            log.warn("Null object provided, can't extract bean properties!");
+            return new PropertyDescriptor[0];
+        }
+
+        try
+        {
+            bi = Introspector.getBeanInfo(obj.getClass());
+            return bi.getPropertyDescriptors();
+        }
+        catch (Exception e)
+        {
+            log.error("Failed to extract properties from: " + obj.getClass(), e);
+            return new PropertyDescriptor[0];
+        }
+    }
+
+    /**
+     * Extracts the value from the Object using the specified property path.
+     *
+     * @param log  for logging
+     * @param obj  the object to extract the value from
+     * @param path the property path, broken up
+     * @return the value, null if failed to located
+     */
+    protected static Object extractValue(Log log, Object obj, List<String> path)
+    {
+        PropertyDescriptor[] props;
+        String current;
+        int index;
+        Object value;
+
+        current = path.get(0);
+        index = -1;
+        if (current.contains("[") && current.endsWith("]"))
+        {
+            index = Integer.parseInt(current.substring(current.indexOf("[") + 1, current.indexOf("]")));
+            current = current.substring(0, current.indexOf("["));
+        }
+
+        props = extractProperties(log, obj);
+        for (PropertyDescriptor prop : props)
+        {
+            if (prop.getDisplayName().equals(current))
+            {
+                try
+                {
+                    value = prop.getReadMethod().invoke(obj);
+                }
+                catch (Exception e)
+                {
+                    value = null;
+                    log.error("Failed to obtain value from path '" + path.get(0) + "!", e);
+                }
+
+                if (index > -1)
+                {
+                    if (value.getClass().isArray())
+                    {
+                        value = Array.get(value, index);
+                    }
+                    else if (value instanceof List)
+                    {
+                        value = ((List) value).get(index);
+                    }
+                    else
+                    {
+                        log.error("Cannot handle type (neither array nor list): " + value.getClass());
+                    }
+                }
+
+                if (path.size() == 1)
+                {
+                    return value;
+                }
+                else
+                {
+                    return extractValue(log, value, path.subList(1, path.size()));
+                }
+            }
+        }
+
+        log.warn("Failed to locate path: " + current);
+        return null;
+    }
+
+    /**
+     * Extracts the value from the Object using the specified property path.
+     *
+     * @param log  for logging
+     * @param obj  the object to extract the value from
+     * @param path the property path
+     * @return the value, null if failed to located
+     */
+    public static Object extractValue(Log log, Object obj, String path)
+    {
+        String[] parts;
+
+        if (path.contains("."))
+        {
+            parts = path.split("\\.");
+        }
+        else
+        {
+            parts = new String[]{path};
+        }
+
+        return extractValue(log, obj, Arrays.asList(parts));
+    }
+}

--- a/src/main/java/de/dentrassi/rpm/builder/FilterUtils.java
+++ b/src/main/java/de/dentrassi/rpm/builder/FilterUtils.java
@@ -1,0 +1,182 @@
+/*******************************************************************************
+ * Copyright (c) 2019 University of Waikato, Hamilton, NZ
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License 2.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-2.0
+ *
+ * Contributors:
+ *     University of Waikato, Hamilton, NZ - initial API and implementation
+ *******************************************************************************/
+package de.dentrassi.rpm.builder;
+
+import org.apache.maven.model.Model;
+import org.apache.maven.plugin.logging.Log;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.nio.file.StandardOpenOption;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * For filtering resources, replacing variables with actual values obtained from the model.
+ *
+ * @author FracPete (fracpete at waikato dot ac dot nz)
+ */
+public class FilterUtils
+{
+
+    public static final String PROJECT = "project.";
+
+    /**
+     * Extracts variables from a line: ${blah} -> blah.
+     *
+     * @param log  for logging
+     * @param line the line to process
+     * @return the variables found
+     */
+    protected static List<String> extractVariables(Log log, String line)
+    {
+        List<String> result;
+        int indexStart;
+        int indexEnd;
+        String original;
+
+        original = line;
+        result = new ArrayList<>();
+        while (line.length() > 0)
+        {
+            indexStart = line.indexOf("${");
+            if (indexStart == -1)
+            {
+                line = "";
+            }
+            else
+            {
+                if ((indexEnd = line.indexOf("}", indexStart)) == -1)
+                {
+                    line = "";
+                }
+                else
+                {
+                    result.add(line.substring(indexStart + 2, indexEnd));
+                    line = line.substring(indexEnd + 1);
+                }
+            }
+        }
+
+        if (result.size() > 0)
+            log.debug("Variables extracted from line '" + original + "': " + result);
+
+        return result;
+    }
+
+    /**
+     * Obtains the variable value from the model ("project.*").
+     *
+     * @param log   for logging
+     * @param var   the variable
+     * @param model the model to obtain the value from
+     * @return null if not found or not a string object, otherwise the value
+     */
+    protected static String variableValue(Log log, String var, Model model)
+    {
+        Object value;
+
+        if (!var.startsWith(PROJECT))
+        {
+            log.warn("Variable does not start with " + PROJECT + ": " + var);
+            return null;
+        }
+
+        value = BeanUtils.extractValue(log, model, var.substring(PROJECT.length()));
+        if (value == null)
+        {
+            log.warn("Failed to extract value for variable: " + var);
+            return null;
+        }
+        else
+        {
+            log.debug("Value for variable " + var + ": " + value);
+            return "" + value;
+        }
+    }
+
+    /**
+     * Filters a file, replacing any project or additional variables in it.
+     *
+     * @param log        for logging
+     * @param input      the input file
+     * @param output     the output file
+     * @param model      the model to use for resolving "project.*" variables
+     * @param additional additional variables with associated values
+     * @throws IOException if reading/writing of file fails
+     */
+    public static void filterFile(Log log, Path input, Path output, Model model, Map<String, String> additional) throws IOException
+    {
+        List<String> lines;
+        int i;
+        String line;
+        List<String> vars;
+        String value;
+        boolean updated;
+        boolean modified;
+        Map<String, String> cache;
+
+        lines = Files.readAllLines(input);
+        cache = new HashMap<>();
+        modified = false;
+        for (i = 0; i < lines.size(); i++)
+        {
+            line = lines.get(i);
+            updated = false;
+            vars = extractVariables(log, line);
+            for (String var : vars)
+            {
+                if (cache.containsKey(var))
+                {
+                    value = cache.get(var);
+                }
+                else if (additional.containsKey(var))
+                {
+                    value = additional.get(var);
+                }
+                else
+                {
+                    value = variableValue(log, var, model);
+                }
+                cache.put(var, value);
+
+                if (value != null)
+                {
+                    log.debug("Replacing variable '" + var + "' with value '" + value + "' in: " + line);
+                    line = line.replace("${" + var + "}", value);
+                    updated = true;
+                }
+            }
+            if (updated)
+            {
+                lines.set(i, line);
+                modified = true;
+            }
+        }
+
+        if (modified)
+        {
+            log.debug("Writing filtered file " + input + " to " + output);
+            Files.createDirectories(output.getParent());
+            Files.write(output, lines, StandardOpenOption.WRITE, StandardOpenOption.TRUNCATE_EXISTING, StandardOpenOption.CREATE);
+        }
+        else
+        {
+            log.debug("Copying unmodified file " + input + " to " + output);
+            Files.createDirectories(output.getParent());
+            Files.copy(input, output, StandardCopyOption.REPLACE_EXISTING);
+        }
+    }
+}

--- a/src/main/java/de/dentrassi/rpm/builder/PackageEntry.java
+++ b/src/main/java/de/dentrassi/rpm/builder/PackageEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBH SYSTEMS GmbH and others.
+ * Copyright (c) 2016,2019 IBH SYSTEMS GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -7,6 +7,7 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     University of Waikato - added filterFile flag
  *******************************************************************************/
 package de.dentrassi.rpm.builder;
 
@@ -95,6 +96,8 @@ public class PackageEntry extends EntryDetails
 
     private String ruleset;
 
+    private boolean filterFile;
+
     public String getName ()
     {
         return this.name;
@@ -153,6 +156,16 @@ public class PackageEntry extends EntryDetails
     public String getRuleset ()
     {
         return this.ruleset;
+    }
+
+    public void setFilterFile( final boolean filterFile )
+    {
+        this.filterFile = filterFile;
+    }
+
+    public boolean getFilterFile()
+    {
+        return this.filterFile;
     }
 
     @Override

--- a/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
+++ b/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBH SYSTEMS GmbH and others.
+ * Copyright (c) 2016, 2018, 2019 IBH SYSTEMS GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,32 +13,14 @@
  *     Lucian Burja - Added setting for creating relocatable RPM packages
  *     Peter Wilkinson - add skip entry flag
  *     Daniel Singhal - Added primary artifact support
+ *     University of Waikato - applying the filterFile flag in fillFromEntryFile
  *******************************************************************************/
 package de.dentrassi.rpm.builder;
 
-import static java.nio.charset.StandardCharsets.US_ASCII;
-import static java.nio.file.Files.readAllLines;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.InetAddress;
-import java.net.UnknownHostException;
-import java.nio.file.FileAlreadyExistsException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Instant;
-import java.time.ZoneOffset;
-import java.time.format.DateTimeFormatter;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Locale;
-import java.util.Optional;
-import java.util.Set;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-
+import com.google.common.base.Strings;
+import com.google.common.io.CharSource;
+import de.dentrassi.rpm.builder.Naming.Case;
+import de.dentrassi.rpm.builder.PackageEntry.Collector;
 import org.apache.maven.model.License;
 import org.apache.maven.plugin.AbstractMojo;
 import org.apache.maven.plugin.MojoExecutionException;
@@ -65,11 +47,30 @@ import org.eclipse.packager.rpm.deps.RpmDependencyFlags;
 import org.eclipse.packager.rpm.signature.RsaHeaderSignatureProcessor;
 import org.eclipse.packager.rpm.signature.SignatureProcessor;
 
-import com.google.common.base.Strings;
-import com.google.common.io.CharSource;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.nio.file.FileAlreadyExistsException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeFormatter;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.Consumer;
+import java.util.function.Supplier;
+import java.util.stream.Collectors;
 
-import de.dentrassi.rpm.builder.Naming.Case;
-import de.dentrassi.rpm.builder.PackageEntry.Collector;
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.file.Files.readAllLines;
 
 /**
  * Build an RPM file
@@ -1027,17 +1028,48 @@ public class RpmMojo extends AbstractMojo
         ctx.addDirectory ( entry.getName (), makeProvider ( entry, "      - " ) );
     }
 
+    private Map<String,String> getAdditionalVars()
+    {
+        HashMap<String,String> additional = new HashMap<>();
+        additional.put("packageName", packageName);
+        additional.put("packager", packager);
+        additional.put("description", description);
+        additional.put("distribution", distribution);
+        additional.put("group", group);
+        additional.put("sourcePackage", sourcePackage);
+        additional.put("vendor", vendor);
+        additional.put("version", version);
+        return additional;
+    }
+
     private void fillFromEntryFile ( final BuilderContext ctx, final PackageEntry entry ) throws IOException
     {
         this.logger.debug ( "    as file:" );
         final Path source = entry.getFile ().toPath ().toAbsolutePath ();
         this.logger.debug ( "      - source: %s", source );
 
-        ctx.addFile ( entry.getName (), source, makeProvider ( entry, "      - " ) );
+        if (entry.getFilterFile())
+        {
+            File tmpFile = new File( System.getProperty( "java.io.tmpdir" ) + File.separator + "rpm-" + System.currentTimeMillis() + "-" + entry.getFile().getName() );
+            tmpFile.deleteOnExit();
+            final Path filtered = tmpFile.toPath();
+            FilterUtils.filterFile( getLog(), source, filtered, project.getModel(), getAdditionalVars() );
+            this.logger.debug ( "      - filtered: %s", filtered );
+            ctx.addFile ( entry.getName (), filtered, makeProvider ( entry, "      - " ) );
+        }
+        else
+        {
+            ctx.addFile ( entry.getName (), source, makeProvider ( entry, "      - " ) );
+        }
     }
 
     private void fillFromEntryLinkTo ( final BuilderContext ctx, final PackageEntry entry ) throws IOException
     {
+        if (entry.getFilterFile())
+        {
+            getLog().error( "Cannot filter symbolic link: " + entry.getLinkTo() );
+        }
+
         this.logger.debug ( "    as symbolic link:" );
         this.logger.debug ( "      - linkTo: %s", entry.getLinkTo () );
         ctx.addSymbolicLink ( entry.getName (), entry.getLinkTo (), makeProvider ( entry, "      - " ) );
@@ -1045,6 +1077,12 @@ public class RpmMojo extends AbstractMojo
 
     private void fillFromEntryCollect ( final BuilderContext ctx, final PackageEntry entry ) throws IOException
     {
+
+        if (entry.getFilterFile())
+        {
+            getLog().error( "Cannot filter from collect: " + entry.getName() );
+        }
+
         this.logger.debug ( "    as collector:" );
 
         final Collector collector = entry.getCollect ();
@@ -1110,7 +1148,6 @@ public class RpmMojo extends AbstractMojo
             {
                 RpmMojo.this.logger.debug ( "%s%s (file)", padding, file );
                 RpmMojo.this.logger.debug ( "%s  - target: %s", padding, targetName );
-
                 ctx.addFile ( targetName, file, provider );
             }
         }

--- a/src/site/markdown/entry.md
+++ b/src/site/markdown/entry.md
@@ -40,6 +40,29 @@ There is no need for additional source information.
 Adding a single file is done by: `<file>path/to/file</file>`. The path to the file is relative
 to the Maven project.
 
+Since version `1.3.1`, you can add `<filterFile>true</filterFile>`,
+if you want the file content to be filtered before being added to the RPM.
+This allows you to place variables (`${varname}`) in the file and have them
+expanded on-the-fly.
+
+In terms of what variables are supported, there are two types:
+The *first* type being POM related ones, that start with `project.` like
+`project.name` or `project.version`. Sub-properties from properties
+in the POM that allow multiple values, like `licenses` can access these
+via `[index]`, with the index being 0-based. The *second* type are
+ones specific to this plugin. Here is a list of supported variables:
+
+```
+description
+distribution
+group
+packageName
+packager
+sourcePackage
+vendor
+version
+```
+
 ### Symbolic link
 
 Adding a single file is done by: `<linkTo>link/target</linkTo>`. The path where the


### PR DESCRIPTION
* similar to the file filtering in the [debian-maven-plugin](https://github.com/fracpete/debian-maven-plugin) plugin (`BeanUtils`, `FilterUtils` classes stem from that project)
* filtering gets activated for a file with the `<filterFile>true</filterFile>` tag
* the filtering replaces `${varname}` variables with the actual values
* creates a tmp file with the expanded content, which gets deleted when the JVM exits
* offers access to project variables, like `project.name` (see `src/site/markdown/entry.md`)
* the following, additional variables are available:
  ```
  description
  distribution
  group
  packageName
  packager
  sourcePackage
  vendor
  version
  ```
* this allows having centralized script templates used by multi-module projects, with directories/etc being represented by variables and then expanded at build time, rather than duplicating the scripts