### PR TITLE
Improve Travis CI build Performance

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,9 @@ sudo: false
 
 install: true # Travis idea of install doesn't fit here
 
-before_script: travis_retry mvn -B help:active-profiles
+before_script: mvn -B help:active-profiles
 
-script: travis_retry mvn -B verify -Pits -Dinvoker.streamLogs=true -Dinvoker.debug=false
+script: mvn -B verify -Pits -Dinvoker.streamLogs=true -Dinvoker.debug=false
 
 addons:
    apt:


### PR DESCRIPTION

Does travis_retry really solve the build issues? According to the data in paper [An empirical study of the long duration of continuous integration builds](https://dl.acm.org/doi/10.1007/s10664-019-09695-9), travis_retry can only solve 3% of the build failures. And it may cause unstable build and increase build time.

=====================
If there are any inappropriate modifications in this PR, please give me a reply and I will change them.
