### PR TITLE
Do not require file or directory for ghost entries (#56).

### DIFF
--- a/src/it/test16-ghost/pom.xml
+++ b/src/it/test16-ghost/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>de.dentrassi.maven.rpm.test</groupId>
+	<artifactId>test16-ghost</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>Test Package #16</name>
+	<description>
+	Test ghost file entry handling
+	</description>
+
+	<url>http://dentrassi.de</url>
+
+	<organization>
+		<name>Jens Reimann</name>
+		<url>http://dentrassi.de</url>
+	</organization>
+
+	<licenses>
+		<license>
+			<name>Eclipse Public License - v 1.0</name>
+			<distribution>repo</distribution>
+			<url>https://www.eclipse.org/legal/epl-v10.html</url>
+		</license>
+	</licenses>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<skipSigning>true</skipSigning>
+	</properties>
+
+	<build>
+
+		<plugins>
+			<plugin>
+				<groupId>de.dentrassi.maven</groupId>
+				<artifactId>rpm</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>rpm</goal>
+						</goals>
+						<configuration>
+							<group>Application/Misc</group>
+
+							<outputFileName>test16.rpm</outputFileName>
+
+							<entries>
+								<entry>
+									<name>/tmp/ghost-file-entry</name>
+									<ghost>true</ghost>
+									<user>root</user>
+									<group>root</group>
+									<mode>0644</mode>
+								</entry>
+							</entries>
+
+							<signature>
+								<keyId>${keyId}</keyId>
+								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
+								<passphrase>${passphrase}</passphrase>
+								<hashAlgorithm>SHA1</hashAlgorithm>
+								<skip>${skipSigning}</skip>
+							</signature>
+
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+			<id>sign</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<properties>
+				<skipSigning>false</skipSigning>
+			</properties>
+		</profile>
+	</profiles>
+
+</project>

--- a/src/it/test16-ghost/verify.groovy
+++ b/src/it/test16-ghost/verify.groovy
@@ -1,0 +1,16 @@
+
+def flags ( options ) {
+	Process proc = ('rpm -l ' + options + ' -qp ' + basedir + "/target/test16.rpm").execute();
+	return proc.in.getText().trim();
+}
+
+def all_files = flags("");
+println "Suggests: " + all_files;
+
+def noghost_files = flags("--noghost");
+println "Recommends: " + noghost_files;
+
+return
+	all_files ==  "./tmp/ghost-file-entry" &&
+	noghost_files == ""
+	;

--- a/src/main/java/de/dentrassi/rpm/builder/PackageEntry.java
+++ b/src/main/java/de/dentrassi/rpm/builder/PackageEntry.java
@@ -169,10 +169,11 @@ public class PackageEntry extends EntryDetails
         sources += this.file != null ? 1 : 0;
         sources += this.collect != null ? 1 : 0;
         sources += this.linkTo != null ? 1 : 0;
+        sources += Boolean.TRUE.equals ( this.getGhost () ) ? 1 : 0;
 
         if ( sources != 1 )
         {
-            throw new IllegalStateException ( "Exactly one of 'file', 'directory', 'linkTo' or 'collect' must be specified." );
+            throw new IllegalStateException ( "Exactly one of 'file', 'directory', 'linkTo', 'collect' or 'ghost' must be specified." );
         }
 
         super.validate ();

--- a/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
+++ b/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.nio.ByteBuffer;
 import java.nio.file.FileAlreadyExistsException;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -1101,6 +1102,10 @@ public class RpmMojo extends AbstractMojo
         {
             fillFromEntryCollect ( ctx, entry );
         }
+        else if ( Boolean.TRUE.equals ( entry.getGhost () ) )
+        {
+            fillFromEntryGhost ( ctx, entry );
+        }
     }
 
     private void fillFromEntryDirectory ( final BuilderContext ctx, final PackageEntry entry ) throws IOException
@@ -1116,6 +1121,13 @@ public class RpmMojo extends AbstractMojo
         this.logger.debug ( "      - source: %s", source );
 
         ctx.addFile ( entry.getName (), source, makeProvider ( entry, "      - " ) );
+    }
+
+    private void fillFromEntryGhost ( final BuilderContext ctx, final PackageEntry entry ) throws IOException
+    {
+        this.logger.debug ( "    as ghost:" );
+
+        ctx.addFile ( entry.getName (), ByteBuffer.allocate ( 0 ), makeProvider ( entry, "      - " ) );
     }
 
     private void fillFromEntryLinkTo ( final BuilderContext ctx, final PackageEntry entry ) throws IOException

--- a/src/test/java/de/dentrassi/rpm/builder/PackageEntryTest.java
+++ b/src/test/java/de/dentrassi/rpm/builder/PackageEntryTest.java
@@ -1,0 +1,81 @@
+package de.dentrassi.rpm.builder;
+
+import static org.junit.Assert.*;
+
+import java.io.File;
+
+import org.junit.Test;
+
+public class PackageEntryTest
+{
+    public PackageEntryTest ()
+    {
+        super();
+    }
+
+    @Test
+    public void testValidateNameNull ()
+    {
+        final PackageEntry entry = new PackageEntry ();
+        entry.setLinkTo ( "something-to-link-to" );
+
+        assertThrows ( IllegalStateException.class, () -> entry.validate () );
+    }
+
+    @Test
+    public void testValidateNameEmpty ()
+    {
+        final PackageEntry entry = new PackageEntry ();
+        entry.setName ("");
+        entry.setLinkTo ( "something-to-link-to" );
+
+        assertThrows ( IllegalStateException.class, () -> entry.validate () );
+    }
+
+    @Test
+    public void testValidateNoSource ()
+    {
+        final PackageEntry entry = new PackageEntry ();
+        entry.setName ("some-entry");
+
+        assertThrows ( IllegalStateException.class, () -> entry.validate () );
+    }
+
+    @Test
+    public void testValidateGhostNull ()
+    {
+        final PackageEntry entry = new PackageEntry ();
+        entry.setName ("some-entry");
+        entry.setGhost ( null );
+
+        // no NullPointerException must be thrown
+        assertThrows ( IllegalStateException.class, () -> entry.validate () );
+    }
+
+    @Test
+    public void testValidateGhostSource()
+    {
+        final PackageEntry entry = new PackageEntry ();
+        entry.setName ("some-entry");
+        entry.setGhost ( Boolean.TRUE );
+
+        try {
+            entry.validate ();
+        }
+        catch ( final RuntimeException e)
+        {
+            fail ( "Ghost entries do not require other sources, got error: " + e.getMessage () );
+        }
+    }
+
+    @Test
+    public void testValidateMultipleSourcesGhost()
+    {
+        final PackageEntry entry = new PackageEntry ();
+        entry.setName ("some-entry");
+        entry.setFile ( new File ( "some-file-entry" ) );
+        entry.setGhost ( Boolean.TRUE );
+
+        assertThrows ( IllegalStateException.class, () -> entry.validate () );
+    }
+}


### PR DESCRIPTION
This pull request resolves #56.

Done a few tests with RPM 4.11.x, which does not list any as ghost marked files anymore if the not really documented option ``--noghost`` is been given.
