### PR TITLE
#66 Assign project.build.rpm.outputFileName property

### DIFF
--- a/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
+++ b/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 IBH SYSTEMS GmbH and others.
+ * Copyright (c) 2016, 2018, 2022 IBH SYSTEMS GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -13,6 +13,7 @@
  *     Lucian Burja - Added setting for creating relocatable RPM packages
  *     Peter Wilkinson - add skip entry flag
  *     Daniel Singhal - Added primary artifact support
+ *     Jarkko Sonninen - Added outputFileNameProperty
  *******************************************************************************/
 package de.dentrassi.rpm.builder;
 

--- a/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
+++ b/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
@@ -650,6 +650,18 @@ public class RpmMojo extends AbstractMojo {
     }
 
     /**
+     * Name of the property, which is set according to the final outputFileName
+     *
+     * @since 1.9.1
+     */
+    @Parameter(property = "rpm.outputFileNameProperty", defaultValue="project.build.rpm.outputFileName")
+    String outputFileNameProperty = "project.build.rpm.outputFileName";
+
+    public void setOutputFileNameProperty(final String outputFileNameProperty) {
+        this.outputFileNameProperty = outputFileNameProperty;
+    }
+
+    /**
      * The highest supported RPM version this package must conform to.
      * <p>
      * This allows to set a maximum version of RPM this package must be
@@ -751,7 +763,9 @@ public class RpmMojo extends AbstractMojo {
             this.logger.info("Creating reproducible RPM at timestamp: %s", outputTimestampInstant);
         }
 
-        final Path targetFile = makeTargetFile(targetDir);
+        final String outputFileName = makeTargetFilename();
+        project.getProperties().setProperty(outputFileNameProperty, outputFileName);
+        final Path targetFile = makeTargetFile(targetDir, outputFileName);
 
         this.logger.debug("Max supported RPM version: %s", this.maximumSupportedRpmVersion);
 
@@ -854,8 +868,7 @@ public class RpmMojo extends AbstractMojo {
         return outputFileName;
     }
 
-    private Path makeTargetFile(final Path targetDir) {
-        final String outputFileName = makeTargetFilename();
+    private Path makeTargetFile(final Path targetDir, final String outputFileName) {
         final Path targetFile = targetDir.resolve(outputFileName);
         this.logger.debug("Resolved output file name - fileName: %s, fullName: %s", this.outputFileName, targetFile);
         return targetFile;


### PR DESCRIPTION
Set generated output file name to a property so it can be used in the next maven phases.