### PR TITLE
Default file digest algorithm to SHA-256 and make it configurable

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -212,7 +212,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.8.2</version>
+                    <version>3.12.1</version>
                 </plugin>
 
                 <plugin>

--- a/src/it/test15-default/pom.xml
+++ b/src/it/test15-default/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>de.dentrassi.maven.rpm.test</groupId>
-	<artifactId>test15-md5-only</artifactId>
+	<artifactId>test15-default</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 

--- a/src/it/test15-default/verify.groovy
+++ b/src/it/test15-default/verify.groovy
@@ -8,4 +8,5 @@ println "Verify: " + result
 
 def m1 = result =~ /MD5 digest\: OK/
 def m2 = result =~ /Header SHA1 digest\: OK/
-return m1.find() && m2.find()
+def m3 = result =~ /Payload SHA256 digest\: OK/
+return m1.find() && m2.find() && m3.find()

--- a/src/it/test15-md5-only/pom.xml
+++ b/src/it/test15-md5-only/pom.xml
@@ -54,6 +54,7 @@
 							<version>1.0.0</version>
 							<outputFileName>test15.rpm</outputFileName>
 							<signatureConfiguration>md5-only</signatureConfiguration>
+							<fileDigestAlgorithm>MD5</fileDigestAlgorithm>
 
 							<signature>
 								<keyId>${keyId}</keyId>

--- a/src/it/test17-reproducible-date/verify.groovy
+++ b/src/it/test17-reproducible-date/verify.groovy
@@ -14,7 +14,7 @@ def verify() {
 def result = verify()
 println "Verify: " + result
 
-def expectedMd5Sum = "129cf561ac335e8ddc80da20b27dbb5b";
+def expectedMd5Sum = "93ebadf3ba02fe04ed2365cbc13c489f";
 def md5sum = generateMD5(new File(basedir, "target/test17-1.0.0-0.200901011100.noarch.rpm"))
 if (md5sum != expectedMd5Sum) {
     System.out.format("RPM MD5 doesn't match -  actual: %s, expected: %s%n", md5sum, expectedMd5Sum);

--- a/src/it/test17-reproducible-epoch/verify.groovy
+++ b/src/it/test17-reproducible-epoch/verify.groovy
@@ -14,7 +14,7 @@ def verify() {
 def result = verify()
 println "Verify: " + result
 
-def expectedMd5Sum = "03a9d0fcb6021866dd631615235846a4";
+def expectedMd5Sum = "11162ad70ef55851a3e1375222cd1a4a";
 def md5sum = generateMD5(new File(basedir, "target/test17-1.0.0-0.197001010000.noarch.rpm"))
 if (md5sum != expectedMd5Sum) {
     System.out.format("RPM MD5 doesn't match -  actual: %s, expected: %s%n", md5sum, expectedMd5Sum);

--- a/src/it/test18-file-digest-default/pom.xml
+++ b/src/it/test18-file-digest-default/pom.xml
@@ -4,7 +4,7 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<groupId>de.dentrassi.maven.rpm.test</groupId>
-	<artifactId>test18-file-digest-md5</artifactId>
+	<artifactId>test18-file-digest-default</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>
 

--- a/src/it/test18-file-digest-default/pom.xml
+++ b/src/it/test18-file-digest-default/pom.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>de.dentrassi.maven.rpm.test</groupId>
+	<artifactId>test18-file-digest-md5</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>Test Package #18</name>
+	<description>
+	Test creating an RPM with the default file digest.
+	</description>
+
+	<url>http://dentrassi.de</url>
+
+	<organization>
+		<name>Jens Reimann</name>
+		<url>http://dentrassi.de</url>
+	</organization>
+
+	<licenses>
+		<license>
+			<name>Eclipse Public License - v 1.0</name>
+			<distribution>repo</distribution>
+			<url>https://www.eclipse.org/legal/epl-v10.html</url>
+		</license>
+	</licenses>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<!-- use a predictable timestamp -->
+		<project.build.outputTimestamp>2009-01-01T12:00:00+01:00</project.build.outputTimestamp>
+		<skipSigning>true</skipSigning>
+		<rpm.skipSigning>true</rpm.skipSigning>
+	</properties>
+
+	<build>
+
+		<plugins>
+			<plugin>
+				<groupId>de.dentrassi.maven</groupId>
+				<artifactId>rpm</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>rpm</goal>
+						</goals>
+						<configuration>
+							<group>Application/Misc</group>
+
+							<forceRelease>false</forceRelease>
+							<version>1.0.0</version>
+							<outputFileName>test18.rpm</outputFileName>
+
+							<entries>
+								<entry>
+									<name>/etc/test.txt</name>
+									<file>src/main/resources/test.txt</file>
+									<user>root</user>
+									<group>root</group>
+									<mode>0600</mode>
+								</entry>
+							</entries>
+
+							<signature>
+								<keyId>${keyId}</keyId>
+								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
+								<passphrase>${passphrase}</passphrase>
+								<hashAlgorithm>SHA1</hashAlgorithm>
+								<skip>${skipSigning}</skip>
+							</signature>
+
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+			<id>sign</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<properties>
+				<skipSigning>false</skipSigning>
+			</properties>
+		</profile>
+	</profiles>
+
+</project>

--- a/src/it/test18-file-digest-default/src/main/resources/test.txt
+++ b/src/it/test18-file-digest-default/src/main/resources/test.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/src/it/test18-file-digest-default/verify.groovy
+++ b/src/it/test18-file-digest-default/verify.groovy
@@ -1,0 +1,16 @@
+def dump ( ) {
+	Process proc = ('rpm -q --dump -p ' + basedir + "/target/test18.rpm").execute()
+	return proc.in.getText().trim()
+}
+
+def actual = dump()
+println "Dump: " + actual
+
+def expected = "/etc/test.txt 11 1230807600 a591a6d40bf420404a011733cfb7b190d62c65bf0bcda32b57b277d9ad9f146e 0100600 root root 0 0 0 X"
+
+if (actual != expected) {
+	System.out.format("RPM dump doesn't match -  actual: %s, expected: %s%n", actual, expected);
+	return false;
+}
+
+return true;

--- a/src/it/test18-file-digest-md5/pom.xml
+++ b/src/it/test18-file-digest-md5/pom.xml
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>de.dentrassi.maven.rpm.test</groupId>
+	<artifactId>test18-file-digest-md5</artifactId>
+	<version>1.0.0-SNAPSHOT</version>
+	<packaging>jar</packaging>
+
+	<name>Test Package #18</name>
+	<description>
+	Test creating an RPM with an overridden file digest algorithm.
+	</description>
+
+	<url>http://dentrassi.de</url>
+
+	<organization>
+		<name>Jens Reimann</name>
+		<url>http://dentrassi.de</url>
+	</organization>
+
+	<licenses>
+		<license>
+			<name>Eclipse Public License - v 1.0</name>
+			<distribution>repo</distribution>
+			<url>https://www.eclipse.org/legal/epl-v10.html</url>
+		</license>
+	</licenses>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<!-- use a predictable timestamp -->
+		<project.build.outputTimestamp>2009-01-01T12:00:00+01:00</project.build.outputTimestamp>
+		<skipSigning>true</skipSigning>
+		<rpm.skipSigning>true</rpm.skipSigning>
+	</properties>
+
+	<build>
+
+		<plugins>
+			<plugin>
+				<groupId>de.dentrassi.maven</groupId>
+				<artifactId>rpm</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>rpm</goal>
+						</goals>
+						<configuration>
+							<group>Application/Misc</group>
+
+							<forceRelease>false</forceRelease>
+							<version>1.0.0</version>
+							<outputFileName>test18.rpm</outputFileName>
+							<fileDigestAlgorithm>MD5</fileDigestAlgorithm>
+
+							<entries>
+								<entry>
+									<name>/etc/test.txt</name>
+									<file>src/main/resources/test.txt</file>
+									<user>root</user>
+									<group>root</group>
+									<mode>0600</mode>
+								</entry>
+							</entries>
+
+							<signature>
+								<keyId>${keyId}</keyId>
+								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
+								<passphrase>${passphrase}</passphrase>
+								<hashAlgorithm>SHA1</hashAlgorithm>
+								<skip>${skipSigning}</skip>
+							</signature>
+
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+			<id>sign</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<properties>
+				<skipSigning>false</skipSigning>
+			</properties>
+		</profile>
+	</profiles>
+
+</project>

--- a/src/it/test18-file-digest-md5/src/main/resources/test.txt
+++ b/src/it/test18-file-digest-md5/src/main/resources/test.txt
@@ -1,0 +1,1 @@
+Hello World

--- a/src/it/test18-file-digest-md5/verify.groovy
+++ b/src/it/test18-file-digest-md5/verify.groovy
@@ -1,0 +1,16 @@
+def dump ( ) {
+	Process proc = ('rpm -q --dump -p ' + basedir + "/target/test18.rpm").execute()
+	return proc.in.getText().trim()
+}
+
+def actual = dump()
+println "Dump: " + actual
+
+def expected = "/etc/test.txt 11 1230807600 b10a8db164e0754105b7a99be72e3fe5 0100600 root root 0 0 0 X"
+
+if (actual != expected) {
+	System.out.format("RPM dump doesn't match -  actual: %s, expected: %s%n", actual, expected);
+	return false;
+}
+
+return true;

--- a/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
+++ b/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
@@ -722,6 +722,30 @@ public class RpmMojo extends AbstractMojo {
      * </p>
      *
      * <p>
+     * The following variants are possible (from {@link DigestAlgorithm}, in no particular order):
+     * </p>
+     * <ul>
+     *     <li><code>MD2</code></li>
+     *     <li><code>MD5</code></li>
+     *     <li><code>SHA1</code></li>
+     *     <li><code>Double-SHA</code></li>
+     *     <li><code>SHA-224</code></li>
+     *     <li><code>SHA-256</code> (default)</li>
+     *     <li><code>SHA-384</code></li>
+     *     <li><code>SHA-512</code></li>
+     *     <li><code>RIPE-MD160</code></li>
+     *     <li><code>Tiger-192</code></li>
+     *     <li><code>Haval-5-160</code></li>
+     * </ul>
+     *
+     * <p>
+     *     <strong>NOTE:</strong> This relies on the JVM to provide a {@code MessageDigest} provider. If you choose a
+     *     file digest algorithm for with the JVM doesn't provide an implementation, the build will fail. By default,
+     *     JVMs (as of 1.8) should at least support MD5, SHA1, and SHA256. In practice SHA-224 to SHA-512 are supported
+     *     by most JVMs.
+     * </p>
+     *
+     * <p>
      *     <strong>NOTE:</strong> This used to be <code>MD5</code> in releases before <code>1.10.0</code>. Starting
      *     with <code>1.10.0</code> this defaults to <code>SHA-256</code> and can be overridden using this setting.
      * </p>

--- a/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
+++ b/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
@@ -728,7 +728,7 @@ public class RpmMojo extends AbstractMojo {
      *
      * @since 1.10.0
      */
-    @Parameter(defaultValue = "SHA-256")
+    @Parameter(defaultValue = "SHA-256", property = "rpm.fileDigestAlgorithm")
     String fileDigestAlgorithm;
 
     private Instant outputTimestampInstant;

--- a/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
+++ b/src/main/java/de/dentrassi/rpm/builder/RpmMojo.java
@@ -790,7 +790,9 @@ public class RpmMojo extends AbstractMojo {
         testLeadFlags();
 
         final BuilderOptions options = new BuilderOptions();
-        options.setFileDigestAlgorithm(evalDigestAlgorithm(this.fileDigestAlgorithm));
+        DigestAlgorithm fileDigestAlgorithm = evalDigestAlgorithm(this.fileDigestAlgorithm);
+        this.logger.info("File Digest Algorithm: %s", fileDigestAlgorithm.getAlgorithm());
+        options.setFileDigestAlgorithm(fileDigestAlgorithm);
 
         // setup basic signature processors
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -29,7 +29,7 @@
     <skin>
         <groupId>org.apache.maven.skins</groupId>
         <artifactId>maven-fluido-skin</artifactId>
-        <version>1.8</version>
+        <version>1.11.1</version>
     </skin>
     <custom>
         <fluidoSkin>


### PR DESCRIPTION
This change allows to configure the digest algorithm used for files inside the RPM file. Previously this defaulted to MD5. It is now also possible to override this.

BREAKING CHANGE: By default, this will now create RPMs with a file digest algorithm of SHA-256. It is possible to override this back to MD5.

Closes: https://github.com/ctron/rpm-builder/issues/70