### PR TITLE
refactor: use pgpainless

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,10 +41,10 @@
 
         <maven.version>3.3.9</maven.version>
 
-        <org.bouncycastle.bcpg.version>1.72.2</org.bouncycastle.bcpg.version>
-        <org.bouncycastle.bcprov.version>1.72</org.bouncycastle.bcprov.version>
+        <org.bouncycastle.bcpg.version>1.73</org.bouncycastle.bcpg.version>
+        <org.bouncycastle.bcprov.version>1.73</org.bouncycastle.bcprov.version>
 
-        <packager.version>0.19.0</packager.version>
+        <packager.version>0.19.1-SNAPSHOT</packager.version>
     </properties>
 
     <prerequisites>

--- a/src/it/rpm12-disable/pom.xml
+++ b/src/it/rpm12-disable/pom.xml
@@ -56,7 +56,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test1/pom.xml
+++ b/src/it/test1/pom.xml
@@ -54,7 +54,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test10-defaultname/pom.xml
+++ b/src/it/test10-defaultname/pom.xml
@@ -56,7 +56,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test10-legacyname/pom.xml
+++ b/src/it/test10-legacyname/pom.xml
@@ -59,7 +59,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test11-prefixes/pom.xml
+++ b/src/it/test11-prefixes/pom.xml
@@ -59,7 +59,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test13-skipentry/pom.xml
+++ b/src/it/test13-skipentry/pom.xml
@@ -55,7 +55,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test14-forcerelease/pom.xml
+++ b/src/it/test14-forcerelease/pom.xml
@@ -54,7 +54,6 @@
 						<keyId>${keyId}</keyId>
 						<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 						<passphrase>${passphrase}</passphrase>
-						<hashAlgorithm>SHA1</hashAlgorithm>
 						<skip>${skipSigning}</skip>
 					</signature>
 				</configuration>

--- a/src/it/test14-primaryname/pom.xml
+++ b/src/it/test14-primaryname/pom.xml
@@ -58,7 +58,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test14-snapshotname/pom.xml
+++ b/src/it/test14-snapshotname/pom.xml
@@ -58,7 +58,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test15-default/pom.xml
+++ b/src/it/test15-default/pom.xml
@@ -59,7 +59,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test15-md5-only/pom.xml
+++ b/src/it/test15-md5-only/pom.xml
@@ -60,7 +60,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test15-not-found/pom.xml
+++ b/src/it/test15-not-found/pom.xml
@@ -59,7 +59,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test16-ghost/pom.xml
+++ b/src/it/test16-ghost/pom.xml
@@ -65,7 +65,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test17-reproducible-date/pom.xml
+++ b/src/it/test17-reproducible-date/pom.xml
@@ -56,7 +56,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test17-reproducible-epoch/pom.xml
+++ b/src/it/test17-reproducible-epoch/pom.xml
@@ -56,7 +56,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test18-file-digest-default/pom.xml
+++ b/src/it/test18-file-digest-default/pom.xml
@@ -70,7 +70,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test18-file-digest-md5/pom.xml
+++ b/src/it/test18-file-digest-md5/pom.xml
@@ -71,7 +71,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test2/pom.xml
+++ b/src/it/test2/pom.xml
@@ -54,7 +54,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test3/pom.xml
+++ b/src/it/test3/pom.xml
@@ -54,7 +54,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test4-lowercase/pom.xml
+++ b/src/it/test4-lowercase/pom.xml
@@ -59,7 +59,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test4-uppercase/pom.xml
+++ b/src/it/test4-uppercase/pom.xml
@@ -55,7 +55,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test5-outname/pom.xml
+++ b/src/it/test5-outname/pom.xml
@@ -54,7 +54,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test6-scanner/pom.xml
+++ b/src/it/test6-scanner/pom.xml
@@ -54,7 +54,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test7-nosrcpkg/pom.xml
+++ b/src/it/test7-nosrcpkg/pom.xml
@@ -56,7 +56,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test7-srcpkg/pom.xml
+++ b/src/it/test7-srcpkg/pom.xml
@@ -55,7 +55,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test7-srcpkg2/pom.xml
+++ b/src/it/test7-srcpkg2/pom.xml
@@ -56,7 +56,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test8-newflags/pom.xml
+++ b/src/it/test8-newflags/pom.xml
@@ -67,7 +67,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/test9-maxversion/pom.xml
+++ b/src/it/test9-maxversion/pom.xml
@@ -69,7 +69,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA1</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/yum1/pom.xml
+++ b/src/it/yum1/pom.xml
@@ -54,7 +54,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA256</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/it/yum2/pom.xml
+++ b/src/it/yum2/pom.xml
@@ -79,7 +79,6 @@
 								<keyId>${keyId}</keyId>
 								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
 								<passphrase>${passphrase}</passphrase>
-								<hashAlgorithm>SHA256</hashAlgorithm>
 								<skip>${skipSigning}</skip>
 							</signature>
 

--- a/src/main/java/de/dentrassi/rpm/builder/Signature.java
+++ b/src/main/java/de/dentrassi/rpm/builder/Signature.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBH SYSTEMS GmbH and others.
+ * Copyright (c) 2016, 2023 IBH SYSTEMS GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -7,10 +7,12 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     Red Hat, Inc - use pgpainless
  *******************************************************************************/
 package de.dentrassi.rpm.builder;
 
 import java.io.File;
+import java.nio.file.Path;
 
 public class Signature {
     private String keyId;
@@ -18,8 +20,6 @@ public class Signature {
     private File keyringFile;
 
     private String passphrase;
-
-    private String hashAlgorithm = "SHA512";
 
     private boolean skip;
 
@@ -45,14 +45,6 @@ public class Signature {
 
     public String getPassphrase() {
         return this.passphrase;
-    }
-
-    public void setHashAlgorithm(final String hashAlgorithm) {
-        this.hashAlgorithm = hashAlgorithm;
-    }
-
-    public String getHashAlgorithm() {
-        return this.hashAlgorithm;
     }
 
     public void setSkip(final boolean skip) {

--- a/src/main/java/de/dentrassi/rpm/builder/SigningHelper.java
+++ b/src/main/java/de/dentrassi/rpm/builder/SigningHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 IBH SYSTEMS GmbH and others.
+ * Copyright (c) 2016, 2023 IBH SYSTEMS GmbH and others.
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License 2.0
  * which accompanies this distribution, and is available at
@@ -7,25 +7,29 @@
  *
  * Contributors:
  *     IBH SYSTEMS GmbH - initial API and implementation
+ *     Red Hat, Inc - use pgpainless
  *******************************************************************************/
 package de.dentrassi.rpm.builder;
-
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.MojoFailureException;
 import org.bouncycastle.openpgp.PGPException;
-import org.bouncycastle.openpgp.PGPPrivateKey;
-import org.eclipse.packager.security.pgp.PgpHelper;
+import org.bouncycastle.openpgp.PGPSecretKeyRing;
+import org.bouncycastle.openpgp.PGPSecretKeyRingCollection;
+import org.bouncycastle.openpgp.operator.bc.BcKeyFingerprintCalculator;
+import org.pgpainless.key.protection.SecretKeyRingProtector;
+import org.pgpainless.util.Passphrase;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
 
 public final class SigningHelper {
 
     private SigningHelper() {
     }
 
-    public static PGPPrivateKey loadKey(final Signature signature, final Logger logger) throws MojoFailureException, MojoExecutionException {
+    public static PGPSecretKeyRing loadKey(final Signature signature, final Logger logger) throws MojoFailureException, MojoExecutionException {
         if (signature == null) {
             return null;
         }
@@ -42,19 +46,25 @@ public final class SigningHelper {
             throw new MojoFailureException(signature, "'keyringFile' parameter not set", "Signing requires the 'keyringFile' to be set to a valid GPG keyring file, containing the secret keys.");
         }
 
-        if (signature.getPassphrase() == null) {
-            throw new MojoFailureException(signature, "'passphrase' parameter not set", "Signing requires the 'passphrase' parameter to be set.");
-        }
-
-        try (InputStream input = new FileInputStream(signature.getKeyringFile())) {
-            final PGPPrivateKey privateKey = PgpHelper.loadPrivateKey(input, signature.getKeyId(), signature.getPassphrase());
-            if (privateKey == null) {
+        try (InputStream input = Files.newInputStream(signature.getKeyringFile().toPath())) {
+            final long keyIdNum = Long.parseLong(signature.getKeyId(), 16);
+            final PGPSecretKeyRing secretKey = new PGPSecretKeyRingCollection(input, new BcKeyFingerprintCalculator())
+                    .getSecretKeyRing(keyIdNum);
+            if (secretKey == null) {
                 throw new MojoFailureException(String.format("Unable to load GPG key '%s' from '%s'", signature.getKeyId(), signature.getKeyringFile()));
             }
-            logger.info("Signing RPM - keyId: %016x", privateKey.getKeyID());
-            return privateKey;
+            logger.info("Signing RPM - keyId: %016x", keyIdNum);
+            return secretKey;
         } catch (final PGPException | IOException e) {
             throw new MojoExecutionException("Failed to load private key for signing", e);
+        }
+    }
+
+    public static SecretKeyRingProtector createProtector(PGPSecretKeyRing secretKey, String passphrase) {
+        if (passphrase == null || passphrase.isEmpty()) {
+            return SecretKeyRingProtector.unprotectedKeys();
+        } else {
+            return SecretKeyRingProtector.unlockAnyKeyWith(Passphrase.fromPassword(passphrase));
         }
     }
 }


### PR DESCRIPTION
This change adapts the changed from Eclipse Packager switching to use pgpainless, simplifying the PGP handling, this solves some gaps in the process.

This correlates to https://github.com/eclipse/packager/pull/48