### PR TITLE
Update JDK to baseline with packager. Update plugin versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
 
         <maven.version>3.8.3</maven.version>
 
-        <org.bouncycastle.bcpg.version>1.77</org.bouncycastle.bcpg.version>
+        <org.bouncycastle.bcpg.version>1.78</org.bouncycastle.bcpg.version>
         <org.bouncycastle.bcprov.version>1.78</org.bouncycastle.bcprov.version>
 
         <packager.version>0.21.0</packager.version>
@@ -133,7 +133,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.15</version>
+            <version>1.16.1</version>
         </dependency>
 
         <!-- EOTD -->
@@ -157,7 +157,7 @@
             <dependency>
                 <groupId>org.apache.commons</groupId>
                 <artifactId>commons-compress</artifactId>
-                <version>1.26.0</version>
+                <version>1.26.1</version>
             </dependency>
             <dependency>
                 <groupId>org.codehaus.plexus</groupId>
@@ -180,10 +180,10 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
-                    <version>3.8.1</version>
+                    <version>3.12.1</version>
                     <configuration>
-                        <source>1.8</source>
-                        <target>1.8</target>
+                        <source>11</source>
+                        <target>11</target>
                     </configuration>
                 </plugin>
 
@@ -239,7 +239,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-invoker-plugin</artifactId>
-                    <version>3.2.2</version>
+                    <version>3.9.0</version>
                 </plugin>
 
                 <plugin>
@@ -251,7 +251,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-enforcer-plugin</artifactId>
-                    <version>1.4.1</version>
+                    <version>3.4.1</version>
                 </plugin>
             </plugins>
         </pluginManagement>
@@ -341,7 +341,7 @@
                         <configuration>
                             <rules>
                                 <requireJavaVersion>
-                                    <version>1.8.0</version>
+                                    <version>11</version>
                                 </requireJavaVersion>
                             </rules>
                         </configuration>
@@ -359,7 +359,7 @@
                 <artifactId>maven-plugin-plugin</artifactId>
                 <configuration>
                     <requiredMavenVersion>3.8</requiredMavenVersion>
-                    <requiredJavaVersion>1.8</requiredJavaVersion>
+                    <requiredJavaVersion>11</requiredJavaVersion>
                 </configuration>
             </plugin>
             <plugin>
@@ -535,7 +535,7 @@
                 <jdk>[1.10,</jdk>
             </activation>
             <properties>
-                <maven.compiler.release>8</maven.compiler.release>
+                <maven.compiler.release>11</maven.compiler.release>
             </properties>
             <build>
                 <pluginManagement>


### PR DESCRIPTION
Packager uses JDK11 (https://github.com/eclipse/packager/blob/master/pom.xml#L74) so this updates from 8 to 11 to match. The dependencies were updated to match the ones from packager.