### PR TITLE
Add version substitution support

### DIFF
--- a/src/it/test21-modifyversion/pom.xml
+++ b/src/it/test21-modifyversion/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
+	<modelVersion>4.0.0</modelVersion>
+
+	<groupId>de.dentrassi.maven.rpm.test</groupId>
+	<artifactId>test21-modifyversion</artifactId>
+	<version>1.0.1.redhat-00001</version>
+	<packaging>jar</packaging>
+
+	<name>Test Package #21</name>
+	<description>Test modify version generation</description>
+
+	<url>https://dentrassi.de</url>
+
+	<organization>
+		<name>Jens Reimann</name>
+		<url>http://dentrassi.de</url>
+	</organization>
+
+	<licenses>
+		<license>
+			<name>Eclipse Public License - v 1.0</name>
+			<distribution>repo</distribution>
+			<url>https://www.eclipse.org/legal/epl-v10.html</url>
+		</license>
+	</licenses>
+
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
+		<skipSigning>true</skipSigning>
+	</properties>
+
+	<build>
+
+		<plugins>
+			<plugin>
+				<groupId>de.dentrassi.maven</groupId>
+				<artifactId>rpm</artifactId>
+				<version>@project.version@</version>
+				<executions>
+					<execution>
+						<goals>
+							<goal>rpm</goal>
+						</goals>
+						<configuration>
+							<attach>false</attach>
+							<group>Application/Misc</group>
+
+							<modifyVersion>true</modifyVersion>
+							<versionReplacements>
+								<versionReplacement>
+									<search>-</search>
+									<replace>_</replace>
+								</versionReplacement>
+							</versionReplacements>
+
+							<signature>
+								<keyId>${keyId}</keyId>
+								<keyringFile>${user.home}/.gnupg/secring.gpg</keyringFile>
+								<passphrase>${passphrase}</passphrase>
+								<hashAlgorithm>SHA1</hashAlgorithm>
+								<skip>${skipSigning}</skip>
+							</signature>
+
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+	<profiles>
+		<profile>
+			<id>sign</id>
+			<activation>
+				<activeByDefault>false</activeByDefault>
+			</activation>
+			<properties>
+				<skipSigning>false</skipSigning>
+			</properties>
+		</profile>
+	</profiles>
+
+</project>

--- a/src/it/test21-modifyversion/verify.groovy
+++ b/src/it/test21-modifyversion/verify.groovy
@@ -1,0 +1,8 @@
+
+def log () {
+    Process proc = ['rpm', '-q', '--queryformat', '[%{VERSION} %{SOURCERPM}]', basedir.toString() + "/target/test21-modifyversion-1.0.1.redhat-00001-1.noarch.rpm"].execute();
+    return proc.in.getText().trim();
+}
+
+String text = log()
+return text.contains("1.0.1.redhat_00001 test21-modifyversion-1.0.1.redhat_00001-1.src.rpm")

--- a/src/site/markdown/index.md
+++ b/src/site/markdown/index.md
@@ -38,6 +38,22 @@ of `1.0.0-SNAPSHOT` will result in `1.0.0-0.201604250101` (depending on the actu
 The result of these rules are SNAPSHOT releases which is always lower than the final release.
 Unless you override using `forceRelease` or `snapshotBuildId`. 
 
+### Version Modification
+
+Beyond the above version specification, there is a facility to modify the version _within_ the RPM. This does not affect the file name of the produced RPM. This is useful if the Maven version is non-compliant with RPM versioning. For example if the Maven version is 1.1.rebuild-00001, the `-` could be replaced by `_` (See https://fedoraproject.org/wiki/PackagingDrafts/TildeVersioning#Basic_versioning_rules)
+
+~~~xml
+    <modifyVersion>true</modifyVersion>
+    <versionReplacements>
+        <versionReplacement>
+            <search>-</search>
+            <replace>_</replace>
+        </versionReplacement>
+    </versionReplacements>
+~~~
+
+Multiple version replacements may be specified and they will be applied in sequence.
+
 ## Contributing
 
 All contributions are welcome!


### PR DESCRIPTION
The reason for this enhancement is that if we have a typical RH version e.g. `1.1.0.redhat-00001` then that utilises illegal characters in the version string - so this PR allows for an optional set of user-defined replacements for such characters.